### PR TITLE
fix bad link in README.md

### DIFF
--- a/demos/morse_server/README.md
+++ b/demos/morse_server/README.md
@@ -45,7 +45,7 @@ For more information about programming on the AtomVM platform, see the [AtomVM P
 | `stm32`        |    ❌     |
 | `generic_unix` |    ❌     |
 
-For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
+For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../../erlang/README.md).
 
 
 


### PR DESCRIPTION
link to the Erlang example program README was incorrect.

Signed-off-by: Winford <dwinford@pm.me>