### PR TITLE
fixed Elixir HelloWorld

### DIFF
--- a/elixir/HelloWorld/lib/HelloWorld.ex
+++ b/elixir/HelloWorld/lib/HelloWorld.ex
@@ -21,7 +21,7 @@
 defmodule HelloWorld do
 
   def start() do
-    :io.format("Hello World~n")
+    :io.format('Hello World~n')
   end
 
 end


### PR DESCRIPTION
elixir io.format expects caracter lists to be `single quoted`, the example did not function correctly because the input was "double quoted" which is considered a String by Elixir.

Signed-off-by: Winford <dwinford@pm.me>