### PR TITLE
Fix bugs in Elixir Blinkly example.

### DIFF
--- a/elixir/Blinky/lib/Blinky.ex
+++ b/elixir/Blinky/lib/Blinky.ex
@@ -28,9 +28,9 @@ defmodule Blinky do
   end
 
   defp loop(pin, level) do
-    IO.format("Setting pin ~p ~p~n", [pin, level])
+    :io.format('Setting pin ~p ~p~n', [pin, level])
     GPIO.digital_write(pin, level)
-    Timer.sleep(1000)
+    :timer.sleep(1000)
     loop(pin, toggle(level))
   end
 

--- a/elixir/Blinky/mix.exs
+++ b/elixir/Blinky/mix.exs
@@ -3,11 +3,15 @@ defmodule Blinky.MixProject do
 
   def project do
     [
-      app: :blinky,
+      app: :Blinky,
       version: "0.1.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      atomvm: [
+        start: Blinky,
+        flash_offset: 0x210000
+      ]
     ]
   end
 


### PR DESCRIPTION
Several of the elixir functions being used in the example have not been implemented yet, so the coresponding erlang functions have been used to make the example functional.
Added missing atomvm project configuration block to mix.exs

Signed-off-by: Winford <dwinford@pm.me>