### PR TITLE
Fix elixir Blinky

### DIFF
--- a/elixir/Blinky/lib/Blinky.ex
+++ b/elixir/Blinky/lib/Blinky.ex
@@ -19,7 +19,6 @@
 #
 
 defmodule Blinky do
-
   @pin 2
 
   def start() do
@@ -30,7 +29,7 @@ defmodule Blinky do
   defp loop(pin, level) do
     :io.format('Setting pin ~p ~p~n', [pin, level])
     GPIO.digital_write(pin, level)
-    :timer.sleep(1000)
+    Process.sleep(1000)
     loop(pin, toggle(level))
   end
 
@@ -41,5 +40,4 @@ defmodule Blinky do
   defp toggle(:low) do
     :high
   end
-
 end


### PR DESCRIPTION
Fix elixir Blinky example to use the native Process.sleep/1 instead of erlangs :timer.sleep/1

Signed-off-by: Winford <dwinford@pm.me>