### PR TITLE
Examples cleanup

### DIFF
--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -38,6 +38,4 @@ jobs:
 
     - name: "Build Erlang Example Programs"
       run: |
-        REBAR="/tmp/rebar3/rebar3"
-        EXAMPLES="arepl_example blinky esp_nvs deep_sleep gpio_interrupt i2c_example hello_world ledc_example read_priv spi_example system_info tcp_client tcp_server uart_example udp_client udp_server wifi"
-        for i in ${EXAMPLES}; do cd ./erlang/$i; ${REBAR} fmt -c || exit 1; ${REBAR} packbeam -p -f -i || exit 1; cd ../..; done
+        PATH=/tmp/rebar3:$PATH ./build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/_build/**
 **/deps/**
 **/mix.lock
+**/rebar3.crashdump

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# This file is part of AtomVM.
+#
+# Copyright 2023 Fred Dushin <fred@dushin.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+REBAR="rebar3"
+cd erlang
+ERLANG_EXAMPLES="$(/bin/ls | grep -v README.md)"
+for i in ${ERLANG_EXAMPLES}; do
+	cd $i
+	rm -rf _build
+	${REBAR} atomvm packbeam -l || exit 1
+	${REBAR} as check fmt -c || exit 1
+	cd ..
+done

--- a/erlang/arepl_example/rebar.config
+++ b/erlang/arepl_example/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/arepl_example/src/arepl_example.app.src
+++ b/erlang/arepl_example/src/arepl_example.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, arepl_example, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/blinky/rebar.config
+++ b/erlang/blinky/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/blinky/src/blinky.app.src
+++ b/erlang/blinky/src/blinky.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, blinky, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/deep_sleep/rebar.config
+++ b/erlang/deep_sleep/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/deep_sleep/src/deep_sleep.app.src
+++ b/erlang/deep_sleep/src/deep_sleep.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, deep_sleep, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/esp_nvs/rebar.config
+++ b/erlang/esp_nvs/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/esp_nvs/src/esp_nvs.app.src
+++ b/erlang/esp_nvs/src/esp_nvs.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, esp_nvs, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/gpio_interrupt/rebar.config
+++ b/erlang/gpio_interrupt/rebar.config
@@ -1,5 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
+]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/gpio_interrupt/src/gpio_interrupt.app.src
+++ b/erlang/gpio_interrupt/src/gpio_interrupt.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, gpio_interrupt, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/hello_world/rebar.config
+++ b/erlang/hello_world/rebar.config
@@ -1,5 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
+]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/hello_world/src/hello_world.app.src
+++ b/erlang/hello_world/src/hello_world.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, hello_world, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/i2c_example/rebar.config
+++ b/erlang/i2c_example/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/i2c_example/src/i2c_example.app.src
+++ b/erlang/i2c_example/src/i2c_example.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, i2c_example, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/ledc_example/rebar.config
+++ b/erlang/ledc_example/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/ledc_example/src/ledc_example.app.src
+++ b/erlang/ledc_example/src/ledc_example.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, ledc_example, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/read_priv/rebar.config
+++ b/erlang/read_priv/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/read_priv/src/read_priv.app.src
+++ b/erlang/read_priv/src/read_priv.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, read_priv, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/spi_example/rebar.config
+++ b/erlang/spi_example/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/spi_example/src/spi_example.app.src
+++ b/erlang/spi_example/src/spi_example.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, spi_example, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/system_info/rebar.config
+++ b/erlang/system_info/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/system_info/src/system_info.app.src
+++ b/erlang/system_info/src/system_info.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, system_info, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/tcp_client/rebar.config
+++ b/erlang/tcp_client/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/tcp_client/src/tcp_client.app.src
+++ b/erlang/tcp_client/src/tcp_client.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, tcp_client, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/tcp_client/src/tcp_client.erl
+++ b/erlang/tcp_client/src/tcp_client.erl
@@ -26,19 +26,20 @@ start() ->
     ok = maybe_start_network(atomvm:platform()),
     Host = maps:get(host, config:get()),
     Port = maps:get(port, config:get()),
+    io:format("Attempting to connect to host ~p on port ~p ...~n", [Host, Port]),
     case gen_tcp:connect(Host, Port, []) of
         {ok, Socket} ->
-            io:format("Connected to ~p from ~p~n", [peer_address(Socket), local_address(Socket)]),
+            io:format("Connected to ~s from ~s~n", [peer_address(Socket), local_address(Socket)]),
             loop(Socket);
         Error ->
             io:format("An error occurred connecting: ~p~n", [Error])
     end.
 
 loop(Socket) ->
-    SendPacket = <<"AtomVM rocks!">>,
+    SendPacket = <<"AtomVM">>,
     case gen_tcp:send(Socket, SendPacket) of
         ok ->
-            io:format("Sent ~p to ~p\n", [SendPacket, peer_address(Socket)]),
+            io:format("Sent ~p to ~s\n", [SendPacket, peer_address(Socket)]),
             receive
                 {tcp_closed, Socket} ->
                     io:format("Connection closed.~n"),
@@ -47,7 +48,7 @@ loop(Socket) ->
                     io:format("TCP error ~p.~n", [Error]),
                     ok;
                 {tcp, Socket, ReceivedPacket} ->
-                    io:format("Received ~p from ~p~n", [ReceivedPacket, peer_address(Socket)]),
+                    io:format("Received ~p from ~s~n", [ReceivedPacket, peer_address(Socket)]),
                     timer:sleep(1000),
                     loop(Socket);
                 Other ->
@@ -76,7 +77,7 @@ maybe_start_network(esp32) ->
     case network:wait_for_sta(Config, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             ok;

--- a/erlang/tcp_server/rebar.config
+++ b/erlang/tcp_server/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/tcp_server/src/tcp_server.app.src
+++ b/erlang/tcp_server/src/tcp_server.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, tcp_server, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/tcp_server/src/tcp_server.erl
+++ b/erlang/tcp_server/src/tcp_server.erl
@@ -27,7 +27,7 @@ start() ->
     Port = maps:get(port, config:get()),
     case gen_tcp:listen(Port, []) of
         {ok, ListenSocket} ->
-            io:format("Listening on ~p.~n", [local_address(ListenSocket)]),
+            io:format("Listening on ~s.~n", [local_address(ListenSocket)]),
             spawn(fun() -> accept(ListenSocket) end),
             timer:sleep(infinity);
         Error ->
@@ -38,7 +38,7 @@ accept(ListenSocket) ->
     io:format("Waiting to accept connection...~n"),
     case gen_tcp:accept(ListenSocket) of
         {ok, Socket} ->
-            io:format("Accepted connection.  local: ~p peer: ~p~n", [
+            io:format("Accepted connection.  local: ~s peer: ~s~n", [
                 local_address(Socket), peer_address(Socket)
             ]),
             spawn(fun() -> accept(ListenSocket) end),
@@ -57,7 +57,7 @@ echo(Socket) ->
             io:format("TCP error ~p.~n", [Error]),
             ok;
         {tcp, Socket, Packet} ->
-            io:format("Received packet ~p from ~p.  Echoing back...~n", [
+            io:format("Received packet ~p from ~s.  Echoing back...~n", [
                 Packet, peer_address(Socket)
             ]),
             gen_tcp:send(Socket, Packet),
@@ -85,7 +85,7 @@ maybe_start_network(esp32) ->
     case network:wait_for_sta(Config, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             ok;

--- a/erlang/uart_example/rebar.config
+++ b/erlang/uart_example/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/uart_example/src/uart_example.app.src
+++ b/erlang/uart_example/src/uart_example.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, uart_example, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/udp_client/rebar.config
+++ b/erlang/udp_client/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/udp_client/src/udp_client.app.src
+++ b/erlang/udp_client/src/udp_client.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, udp_client, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/udp_client/src/udp_client.erl
+++ b/erlang/udp_client/src/udp_client.erl
@@ -26,19 +26,19 @@ start() ->
     ok = maybe_start_network(atomvm:platform()),
     case gen_udp:open(0) of
         {ok, Socket} ->
-            io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
+            io:format("Opened UDP socket on ~s.~n", [local_address(Socket)]),
             loop(Socket);
         Error ->
             io:format("An error occurred opening UDP socket: ~p~n", [Error])
     end.
 
 loop(Socket) ->
-    Packet = <<"AtomVM rocks!">>,
+    Packet = <<"AtomVM">>,
     Host = maps:get(host, config:get()),
     Port = maps:get(port, config:get()),
     case gen_udp:send(Socket, Host, Port, Packet) of
         ok ->
-            io:format("Sent ~p to ~p:~p~n", [Packet, Host, Port]);
+            io:format("Sent ~p to ~s~n", [Packet, to_string({Host, Port})]);
         Error ->
             io:format("An error occurred sending a packet: ~p~n", [Error])
     end,
@@ -59,7 +59,7 @@ maybe_start_network(esp32) ->
     case network:wait_for_sta(Config, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             ok;

--- a/erlang/udp_server/rebar.config
+++ b/erlang/udp_server/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/udp_server/src/udp_server.app.src
+++ b/erlang/udp_server/src/udp_server.app.src
@@ -26,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.

--- a/erlang/udp_server/src/udp_server.erl
+++ b/erlang/udp_server/src/udp_server.erl
@@ -27,7 +27,7 @@ start() ->
     Port = maps:get(port, config:get()),
     case gen_udp:open(Port, [{active, true}]) of
         {ok, Socket} ->
-            io:format("Opened UDP socket on ~p.~n", [local_address(Socket)]),
+            io:format("Opened UDP socket on ~s.~n", [local_address(Socket)]),
             loop();
         Error ->
             io:format("An error occurred opening UDP socket: ~p~n", [Error])
@@ -37,7 +37,7 @@ loop() ->
     io:format("Waiting to receive data...~n"),
     receive
         {udp, _Socket, Address, Port, Packet} ->
-            io:format("Received UDP packet ~p from ~p~n", [Packet, to_string({Address, Port})])
+            io:format("Received UDP packet ~p from ~s~n", [Packet, to_string({Address, Port})])
     end,
     loop().
 
@@ -55,7 +55,7 @@ maybe_start_network(esp32) ->
     case network:wait_for_sta(Config, 30000) of
         {ok, {Address, Netmask, Gateway}} ->
             io:format(
-                "Acquired IP address: ~p Netmask: ~p Gateway: ~p~n",
+                "Acquired IP address: ~s Netmask: ~s Gateway: ~s~n",
                 [to_string(Address), to_string(Netmask), to_string(Gateway)]
             ),
             ok;

--- a/erlang/wifi/rebar.config
+++ b/erlang/wifi/rebar.config
@@ -1,8 +1,32 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {erl_opts, [debug_info]}.
 {deps, []}.
 {plugins, [
-    atomvm_rebar3_plugin, erlfmt
+    atomvm_rebar3_plugin
 ]}.
 {atomvm_rebar3_plugin, [
     {packbeam, [prune]}
+]}.
+{profiles, [
+    {check, [
+        {plugins, [erlfmt]}
+    ]}
 ]}.

--- a/erlang/wifi/src/wifi.app.src
+++ b/erlang/wifi/src/wifi.app.src
@@ -1,3 +1,22 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2023 Fred Dushin <fred@dushin.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
 {application, wifi, [
     {description, "An AtomVM application"},
     {vsn, "0.1.0"},
@@ -7,6 +26,6 @@
     ]},
     {env, []},
     {modules, []},
-    {licenses, ["Apache 2.0"]},
+    {licenses, ["Apache-2.0"]},
     {links, []}
 ]}.


### PR DESCRIPTION
This change set includes some cleanup and improvements to the Erlang examples.

* Fixed TCP and UDP examples to print IP addresses and port numbers in a more readable way
* Update copyright and license files
* Use profiles to only require `erlfmt` when running a check
* Use a build script in CI and for local testing