### PR TITLE
Update documentation with new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ The example programs in this collection require the following:
 * Elixir applications:
     * [Elixir](https://elixir-lang.org) Version 1.13 (version compatible with OTP version selected above)
 
-See the [AtomVM Release Notes](https://www.atomvm.net/doc/master/release-notes.html) for information about supported versions of the above software.
+See the [AtomVM Release Notes](https://doc.atomvm.org/latest/release-notes.html) for information about supported versions of the above software.
 
 For instructions about how to install these requirements, consult your local operating system documentation and package management system.
 
-The above tools make use of plugins designed specifically to simply the development and deployment of applications on to supported platforms.  For more information about these plugins, please refer to the [AtomVM Tooling](https://www.atomvm.net/doc/master/atomvm-tooling.html) documentation.
+The above tools make use of plugins designed specifically to simply the development and deployment of applications on to supported platforms.  For more information about these plugins, please refer to the [AtomVM Tooling](https://doc.atomvm.org/latest/atomvm-tooling.html) documentation.
 
-These instructions assume you have already deployed the AtomVM virtual machine on to the device on which you are running.  For instructions about how to install the AtomVM virtual machine onto devices, see the AtomVM [Getting Started Guide](https://www.atomvm.net/doc/master/getting-started-guide.html).
+These instructions assume you have already deployed the AtomVM virtual machine on to the device on which you are running.  For instructions about how to install the AtomVM virtual machine onto devices, see the AtomVM [Getting Started Guide](https://doc.atomvm.org/latest/getting-started-guide.html).
 
 ### ESP32 Requirements
 
@@ -45,7 +45,7 @@ In order to flash and run these programs on an ESP32 device, you will need, in a
 * Some example applications require the presence of a WiFi Access Point (AP), to which the ESP32 device can connect.
 * Some example applications require either an existing WiFi Access Point (AP) or that your personal computer be capable of connecting to the ESP32 acting as a WiFi Access Point (AP).
 
-> For information about supported ESP32 SoCs, see the AtomVM [Release Notes](https://www.atomvm.net/doc/master/release-notes.html).
+> For information about supported ESP32 SoCs, see the AtomVM [Release Notes](https://doc.atomvm.org/latest/release-notes.html).
 
 ### STM32 Requirements
 
@@ -58,7 +58,7 @@ In order to flash and run these programs on an STM32 device, you will need, in a
 * To use JTAG for flashing and console output debugging, you will need a [st-link v2](https://www.st.com/en/development-tools/st-link-v2.html) or [st-link v3](https://www.st.com/en/development-tools/stlink-v3set.html) device (typically already included on Nucleo and Discovery boards).
 * (Recommended) A serial console program, such as [`minicom`](https://en.wikipedia.org/wiki/Minicom).
 
-> For information about supported STM32 development boards, see the AtomVM [Release Notes](https://www.atomvm.net/doc/master/release-notes.html).
+> For information about supported STM32 development boards, see the AtomVM [Release Notes](https://doc.atomvm.org/latest/release-notes.html).
 
 ### Raspberry Pico Requirements
 
@@ -70,7 +70,7 @@ In order to flash and run these programs on a Raspberry Pico or Raspberry Pico W
 * (Recommended) A serial console program, such as [`minicom`](https://en.wikipedia.org/wiki/Minicom).
 * Some example applications require the presence of a WiFi Access Point (AP), to which the Raspberry Pico W device can connect.  Note that these examples are only supported on the Raspberry Pico W.
 
-> For information about supported Raspberry Pico devices, see the AtomVM [Release Notes](https://www.atomvm.net/doc/master/release-notes.html).
+> For information about supported Raspberry Pico devices, see the AtomVM [Release Notes](https://doc.atomvm.org/latest/release-notes.html).
 
 ### Generic Unix Requirements
 

--- a/demos/morse_server/README.md
+++ b/demos/morse_server/README.md
@@ -41,7 +41,7 @@ Your ESP can be reached with a web browser on port 8080 by its IP address or DHC
 
     "http://192.168.0.32:8080"  or  "http://atomvm-240ac458d278:8080"
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 ## Supported Platforms
 

--- a/elixir/Blinky/README.md
+++ b/elixir/Blinky/README.md
@@ -31,6 +31,6 @@ To run this example, depending on how bright you want your led, connect a 220 oh
 
 > Pico-W Note. To use the onboard LED on a `picow` edit lib/Blinky.ex and comment out the current `@pin` definition (change to: `# @pin 2`), and uncomment the definition for the picow onboard LED `@pin` definition: `@pin {:wl, 0}`.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Elixir AtomVM example programs, see the Elixir example program [README](../README.md).

--- a/elixir/HelloWorld/README.md
+++ b/elixir/HelloWorld/README.md
@@ -10,6 +10,6 @@ Welcome to the `HelloWorld` AtomVM application.
 
 The `HelloWorld` AtomVM application prints "Hello World" to the console and then terminates.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Elixir AtomVM example programs, see the Elixir example program [README](../README.md).

--- a/elixir/LEDC_Example/README.md
+++ b/elixir/LEDC_Example/README.md
@@ -13,6 +13,6 @@ The `LEDC_Example` AtomVM application illustrates use of the AtomVM `LEDC` inter
 LEDs are wired to GPIO pins 4, 5, 18, and 19 and should use a resistor (minimum 100 Ohm up to 1K, 220 Ohm is a good choice). Change the number
 for the GPIO pins in the example if necessary. See the Blinky example for wiring if you are unsure.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/README.md
+++ b/erlang/README.md
@@ -41,7 +41,7 @@ To build and run an example in this directory, change your working directory to 
 
 The following generic instructions apply to the Erlang examples in this repository.  Special notes about building and running the example programs that deviate from these instructions are noted in the README file for the particular example program.
 
-These instructions make use of the [`atomvm_rebar3_plugin`](https://atomvm.github.io/atomvm_rebar3_plugin).  For more information about AtomVM tooling, please see the [AtomVM Tooling](https://www.atomvm.net/doc/master/atomvm-tooling.html) documentation.
+These instructions make use of the [`atomvm_rebar3_plugin`](https://atomvm.github.io/atomvm_rebar3_plugin).  For more information about AtomVM tooling, please see the [AtomVM Tooling](https://doc.atomvm.org/latest/atomvm-tooling.html) documentation.
 
 ### Building
 
@@ -73,7 +73,7 @@ To run this application on the STM32 platform, you must flash the application to
 
 #### Flashing onto an STM32 Device
 
-The STM32 platform requires that the core AtomVM library be included in the application you are targeting for the device.  For information about how to obtain this library, see the [AtomVM Tooling](https://www.atomvm.net/doc/master/atomvm-tooling.html) documentation.
+The STM32 platform requires that the core AtomVM library be included in the application you are targeting for the device.  For information about how to obtain this library, see the [AtomVM Tooling](https://doc.atomvm.org/latest/atomvm-tooling.html) documentation.
 
 Once you have obtained this library, you must use the `packeam` task to create the AVM file to deploy to your device.  Specify the path to the AtomVM core library using the `-e` option, e.g.,
 
@@ -115,4 +115,4 @@ To run this application on a generic UNIX platform, supply the path to the gener
 
 where `<example-program>` is the name of the example program.
 
-> Note.  See the AtomVM [Getting Started Guide](https://www.atomvm.net/doc/master/getting-started-guide.html) for information about how to install AtomVM on the generic UNIX platform.
+> Note.  See the AtomVM [Getting Started Guide](https://doc.atomvm.org/latest/getting-started-guide.html) for information about how to install AtomVM on the generic UNIX platform.

--- a/erlang/arepl_example/README.md
+++ b/erlang/arepl_example/README.md
@@ -10,7 +10,7 @@ Welcome to the `arepl_example` AtomVM application.
 
 The `arepl_example` AtomVM application demonstrates the use of the `arepl` LISP interpreter.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 ## Build and Run Instructions
 

--- a/erlang/blinky/README.md
+++ b/erlang/blinky/README.md
@@ -31,6 +31,6 @@ To run this example, depending on how bright you want your led, connect a 220 oh
 
 > Pico W Note. To use the onboard LED on a `picow` edit src/blinky.erl and comment out the current `PIN` definition (change to: `% -define(PIN, 2).`), and uncomment the definition for the `picow` onboard LED definition: `-define(PIN, {wl, 0}).`
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/deep_sleep/README.md
+++ b/erlang/deep_sleep/README.md
@@ -10,6 +10,6 @@ Welcome to the `deep_sleep` AtomVM application.
 
 The `deep_sleep` AtomVM application will put the ESP32 device into low-power deep sleep for 10 seconds, wake up, and report the reset reason.  In most cases this will be `esp_rst_deepsleep`, but the initial reset reason will be `esp_rst_poweron`, or if you reset the device manually during sleep.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/esp_nvs/README.md
+++ b/erlang/esp_nvs/README.md
@@ -10,6 +10,6 @@ Welcome to the `esp_nvs` AtomVM application.
 
 The `esp_nvs` AtomVM application uses the ESP non-volatile storage to record the number of times the device has restarted.  If the NVS storage has not been set for this application, it will be intialized with a count of 0.  The device will then sleep for 10 seconds, and restart.  After each restart, the number of restarts is incremented and stored in non-volatile storage.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/gpio_interrupt/README.md
+++ b/erlang/gpio_interrupt/README.md
@@ -23,6 +23,6 @@ This application will wait in a loop for interrupt signals when GPIO pin 2 is ri
     Waiting for interrupt ... Interrupt on pin 2
     Waiting for interrupt ...
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/hello_world/README.md
+++ b/erlang/hello_world/README.md
@@ -10,6 +10,6 @@ Welcome to the `hello_world` AtomVM application.
 
 The `hello_world` AtomVM application prints "Hello World" to the console and then terminates.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/i2c_example/README.md
+++ b/erlang/i2c_example/README.md
@@ -10,6 +10,6 @@ Welcome to the `i2c_example` AtomVM application.
 
 The `i2c_example` AtomVM application demonstrates use of the `i2c` interface using the popular SHT3x temperature sensor.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/ledc_example/README.md
+++ b/erlang/ledc_example/README.md
@@ -10,6 +10,6 @@ Welcome to the `ledc_example` AtomVM application.
 
 The `ledc_example` AtomVM application illustrates use of the AtomVM `ledc` interface.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/read_priv/README.md
+++ b/erlang/read_priv/README.md
@@ -14,6 +14,6 @@ For this test, note the presence of the `favicon-32x32.png` in the `priv` direct
 
     <<-119,80,78,71,13,10,26,10,0,0,0,...>>
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/spi_example/README.md
+++ b/erlang/spi_example/README.md
@@ -10,6 +10,6 @@ Welcome to the `spi_example` AtomVM application.
 
 The `spi_example` AtomVM application demonstrates use of the `spi` interface with the popular Smetech SX127x LoRa modem.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/system_info/README.md
+++ b/erlang/system_info/README.md
@@ -16,7 +16,7 @@ For example, on the ESP32 platform, this program will output the following infor
     PlatformInfo: #{esp32_chip_info => {esp32,50,2,1},esp32_free_heap_size => 245816,esp32_largest_free_block => 116104,esp32_minimum_free_size => 242136,esp_idf_version => "v3.3.4-dirty"}
     ProcessInfo: [{<0.1.0>,[{heap_size,457},{stack_size,12},{message_queue_len,0},{memory,512}]}]
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 ## Supported Platforms
 

--- a/erlang/tcp_client/README.md
+++ b/erlang/tcp_client/README.md
@@ -30,7 +30,7 @@ If the TCP server is running on a separate host from the client application, you
 
 You can use the `tcp_server` example program to listen for TCP packets from your running application.  Alternatively, you can use a program such as the [netcat](https://en.wikipedia.org/wiki/Netcat) utility to receive TCP packets from the command line.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
 

--- a/erlang/tcp_server/README.md
+++ b/erlang/tcp_server/README.md
@@ -28,7 +28,7 @@ For example:
 
 You can use the `tcp_client` example program to send TCP/IP packets to your running application.  Alternatively, you can use a program such as the [netcat](https://en.wikipedia.org/wiki/Netcat) utility to send TCP packets from the command line.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
 

--- a/erlang/uart_example/README.md
+++ b/erlang/uart_example/README.md
@@ -10,6 +10,6 @@ Welcome to the `uart_example` AtomVM application.
 
 The `uart_example` AtomVM application demonstrates use of the `uart` interface.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).

--- a/erlang/udp_client/README.md
+++ b/erlang/udp_client/README.md
@@ -24,7 +24,7 @@ If the UDP server is running on a separate host from the client application, you
 
 You can use the `udp_server` example program to listen for UDP packets from your running application.  Alternatively, you can use a program such as the [netcat](https://en.wikipedia.org/wiki/Netcat) utility to receive UDP packets from the command line.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
 

--- a/erlang/udp_server/README.md
+++ b/erlang/udp_server/README.md
@@ -19,7 +19,7 @@ For example:
 
 You can use the `udp_client` example program to send UDP packets to your running application.  Alternatively, you can use a program such as the [netcat](https://en.wikipedia.org/wiki/Netcat) utility to send UDP packets from the command line.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
 

--- a/erlang/wifi/README.md
+++ b/erlang/wifi/README.md
@@ -10,7 +10,7 @@ Welcome to the `wifi` AtomVM application.
 
 The `wifi` AtomVM application demonstrates how to configure an ESP32 device for both Station (STA) and Access Point (AP) modes, allowing an ESP32 device to join an existing WiFi network or to serve as a WiFi access point for other devices.
 
-For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://www.atomvm.net/doc/master/programmers-guide.html).
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
 
 For general information about building and executing Erlang AtomVM example programs, see the Erlang example program [README](../README.md).
 


### PR DESCRIPTION
Updates all references to the old www.atomvm.net domain with the new atomvm.org domains.