### PR TITLE
Add Elixir ESP NVS example

### DIFF
--- a/elixir/EspNvs/README.md
+++ b/elixir/EspNvs/README.md
@@ -1,0 +1,16 @@
+<!---
+  Copyright 2026 Masatoshi Nishiguchi
+
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
+# `EspNvs` Application
+
+Welcome to the `EspNvs` AtomVM application.
+
+The `EspNvs` AtomVM application uses ESP32 non-volatile storage (NVS) to store a small value.
+If the NVS storage has not been set for this application, it will store a default value once. The application then logs the result and restarts every 10 seconds.
+
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
+
+For general information about building and executing Elixir AtomVM example programs, see the Elixir example program [README](../README.md).

--- a/elixir/EspNvs/lib/esp_nvs.ex
+++ b/elixir/EspNvs/lib/esp_nvs.ex
@@ -1,0 +1,60 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2026 Masatoshi Nishiguchi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule EspNvs do
+  @moduledoc """
+  Demonstrates ESP32 NVS usage by storing a small value once.
+  """
+
+  @compile {:no_warn_undefined, :atomvm}
+  @compile {:no_warn_undefined, :esp}
+
+  @nvs_namespace :esp_nvs
+  @nvs_key :word
+  @default_word "Hello"
+  @restart_interval_ms 10_000
+
+  def start do
+    case verify_platform(:atomvm.platform()) do
+      :ok ->
+        case :esp.nvs_fetch_binary(@nvs_namespace, @nvs_key) do
+          {:ok, word} when is_binary(word) ->
+            IO.puts("Fetched word from NVS: #{word}")
+
+          {:error, :not_found} ->
+            IO.puts("No word found. Storing default word to NVS once: #{@default_word}")
+            :ok = :esp.nvs_put_binary(@nvs_namespace, @nvs_key, @default_word)
+
+          _ ->
+            IO.puts("Error reading NVS. Skipping write.")
+        end
+
+        IO.puts("Restarting in 10 seconds ...")
+        Process.sleep(@restart_interval_ms)
+        :esp.restart()
+
+      error ->
+        error
+    end
+  end
+
+  defp verify_platform(:esp32), do: :ok
+  defp verify_platform(platform), do: {:error, {:unsupported_platform, platform}}
+end

--- a/elixir/EspNvs/mix.exs
+++ b/elixir/EspNvs/mix.exs
@@ -1,0 +1,51 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2026 Masatoshi Nishiguchi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule EspNvs.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :esp_nvs,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      atomvm: [
+        start: EspNvs,
+        flash_offset: 0x250000
+      ]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:exatomvm, git: "https://github.com/atomvm/ExAtomVM/", branch: "main"}
+    ]
+  end
+end

--- a/elixir/EspRtcMemory/README.md
+++ b/elixir/EspRtcMemory/README.md
@@ -1,0 +1,16 @@
+<!---
+  Copyright 2026 Masatoshi Nishiguchi
+
+  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+-->
+
+# `EspRtcMemory` Application
+
+Welcome to the `EspRtcMemory` AtomVM application.
+
+The `EspRtcMemory` AtomVM application uses ESP32 RTC slow memory to record the number of times the device has restarted.
+If no value has been stored in RTC slow memory yet, the counter is initialized to 0. The device will then sleep for 10 seconds and restart. After each restart, the counter is incremented and stored back to RTC slow memory.
+
+For more information about programming on the AtomVM platform, see the [AtomVM Programmers Guide](https://doc.atomvm.org/latest/programmers-guide.html).
+
+For general information about building and executing Elixir AtomVM example programs, see the Elixir example program [README](../README.md).

--- a/elixir/EspRtcMemory/lib/esp_rtc_memory.ex
+++ b/elixir/EspRtcMemory/lib/esp_rtc_memory.ex
@@ -1,0 +1,100 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2026 Masatoshi Nishiguchi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule EspRtcMemory do
+  @moduledoc """
+  Demonstrates ESP32 RTC slow memory usage by persisting a restart counter.
+  """
+
+  @compile {:no_warn_undefined, :atomvm}
+  @compile {:no_warn_undefined, :esp}
+
+  @restart_delay_ms 10_000
+
+  def start do
+    case verify_platform(:atomvm.platform()) do
+      :ok ->
+        load_state()
+        |> increment_state()
+        |> save_state()
+
+        IO.puts("Restarting in 10 seconds ...")
+        Process.sleep(@restart_delay_ms)
+        :esp.restart()
+
+      error ->
+        error
+    end
+  end
+
+  defp load_state do
+    IO.puts("Loading count from RTC slow memory ...")
+
+    encoded_term =
+      try do
+        :esp.rtc_slow_get_binary()
+      catch
+        :error, :badarg ->
+          IO.puts("This device has not recorded the number of starts. Initializing to 0.")
+          :erlang.term_to_binary(%RebootState{})
+      end
+
+    case safe_binary_to_term(encoded_term) do
+      {:ok, %RebootState{count: count} = state} when is_integer(count) and count >= 0 ->
+        state
+
+      _ ->
+        IO.puts("Error: bad value, resetting to 0.")
+        %RebootState{}
+    end
+  end
+
+  defp safe_binary_to_term(encoded_term) when is_binary(encoded_term) do
+    try do
+      {:ok, :erlang.binary_to_term(encoded_term)}
+    catch
+      :error, _ ->
+        :error
+    end
+  end
+
+  defp save_state(current_state) do
+    IO.puts("Saving count to RTC slow memory ...")
+
+    current_state
+    |> :erlang.term_to_binary()
+    |> :esp.rtc_slow_set_binary()
+  end
+
+  defp increment_state(%RebootState{count: count} = state) when is_integer(count) and count >= 0 do
+    new_count = count + 1
+    IO.puts("This device has restarted #{new_count} time(s).")
+    %RebootState{state | count: new_count}
+  end
+
+  defp increment_state(_) do
+    IO.puts("Error: bad value, resetting to 0.")
+    %RebootState{}
+  end
+
+  defp verify_platform(:esp32), do: :ok
+  defp verify_platform(platform), do: {:error, {:unsupported_platform, platform}}
+end
+

--- a/elixir/EspRtcMemory/lib/reboot_state.ex
+++ b/elixir/EspRtcMemory/lib/reboot_state.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2026 Masatoshi Nishiguchi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule RebootState do
+  @moduledoc """
+  Holds the reboot counter persisted in RTC slow memory.
+  """
+
+  defstruct count: 0
+end
+

--- a/elixir/EspRtcMemory/mix.exs
+++ b/elixir/EspRtcMemory/mix.exs
@@ -1,0 +1,51 @@
+#
+# This file is part of AtomVM.
+#
+# Copyright 2026 Masatoshi Nishiguchi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+
+defmodule EspRtcMemory.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :esp_rtc_memory,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      atomvm: [
+        start: EspRtcMemory,
+        flash_offset: 0x250000
+      ]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:exatomvm, git: "https://github.com/atomvm/ExAtomVM/", branch: "main"}
+    ]
+  end
+end

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -16,8 +16,10 @@ Some example programs can only run on specific platform.  The following table su
 |-----------------|-------|-------|------|--------|--------------|
 | Blinky          | ✅ | ✅ | ✅ | ✦ | ❌ |
 | HelloWorld      | ✅ | ✅ | ✅ | ✅ | ✅ |
-| LEDC_Example    | ✅ | ❌ | ❌ | ❌ | ❌ |
-| WifiExample     | ✅ | ❌ | ❌ | ✅ | ❌ |
+| LEDC            | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Wifi            | ✅ | ❌ | ❌ | ✅ | ❌ |
+| EspNvs          | ✅ | ❌ | ❌ | ❌ | ❌ |
+| EspRtcMemory    | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ✦ Works, but requires editing to use onboard LED, see the README in the examples directory.
 


### PR DESCRIPTION
I tested it with my ESP32-S3 + v0.6.6 image.

Here is example log output:
```
AtomVM init.
I (609) sys: Loaded BEAM partition main.avm at address 0x250000 (size=1048576 bytes)
Starting application...
Loading count from NVS ...
Loaded count: 313
This device has restarted 314 time(s).
Saving count to NVS ...
Restarting in 10 seconds ...
```
